### PR TITLE
Fixed notice in PHP 7.3

### DIFF
--- a/src/Manager.php
+++ b/src/Manager.php
@@ -182,7 +182,7 @@ class Manager extends Model {
 			if ($added) $keep = $keep . '\\' . $added;
 
 			// If the namespace is already in the namespace suffix specified, do not put it in there twice.
-			$finalNs = (strpos($nsSuffix, $keep) !== 0) ? "{$keep}{$nsSuffix}" : $nsSuffix;
+			$finalNs = ($keep && strpos($nsSuffix, $keep) !== 0) ? "{$keep}{$nsSuffix}" : $nsSuffix;
 
 			foreach ($classSuffixes as $classSuffix) {
 				$list[] = $this->buildFullClass($modelName, $finalNs, $classSuffix);


### PR DESCRIPTION
- In strpos() needle can't be empty or null.
- Full error: strpos(): Non-string needles will be interpreted as strings in the future. Use an explicit chr() call to preserve the current behavior.